### PR TITLE
added unit testing for sFinger double tap

### DIFF
--- a/gesturelibrary/test/test_gesturelib.cpp
+++ b/gesturelibrary/test/test_gesturelib.cpp
@@ -55,3 +55,24 @@ TEST(GestureLibraryHoldTest, TestGestureHoldTester) {
 
     EXPECT_EQ(get_sFingerHold()[0].state, possible);
 }
+
+TEST(GestureLibrarySFingerDoubleTest, TestGestureSingleDouble) {
+    init_gesturelib();
+
+    touch_event_t event1;
+    event1.position_x = 100;
+    event1.position_y = 200;
+    event1.timestamp  = 42;
+
+    touch_event_t event2;
+    event2.position_x = 100;
+    event2.position_y = 200;
+    event2.timestamp  = 44;
+
+    gesture_event_t gestures[1];
+
+    process_touch_event(&event1, gestures, 4);
+    process_touch_event(&event2, gestures, 4);
+
+    EXPECT_EQ(get_sFingerDTap()[0].state, possible);
+}


### PR DESCRIPTION
This unit testing is for the single finger double tap gesture. It initiates two touch events that are within a few msecs of each other and verifies that, after pushing the first one then the second one, the state changes to possible. Failure testing will need to also be implemented (two taps too far apart in terms of distance or time).